### PR TITLE
Add request for password if document locked

### DIFF
--- a/apps/visualizer/src/constant/password.ts
+++ b/apps/visualizer/src/constant/password.ts
@@ -1,0 +1,5 @@
+const TOO_MANY_PASSWORD_ATTEMPTS =
+  "Too many password attempts. Please try again later.";
+const ENTER_PASSWORD = "Please enter the password for the PDF file.";
+
+export { TOO_MANY_PASSWORD_ATTEMPTS, ENTER_PASSWORD };

--- a/apps/visualizer/src/utils/readFile.ts
+++ b/apps/visualizer/src/utils/readFile.ts
@@ -1,11 +1,30 @@
 import { parseStatement, Transaction } from "@parser"
+import {
+  ENTER_PASSWORD,
+  TOO_MANY_PASSWORD_ATTEMPTS,
+} from "../constant/password"
+
+const handleRequestPassword = (updatePassword: (password: string) => void) => {
+  const password = prompt(ENTER_PASSWORD)
+  updatePassword(password)
+}
+
+const handleMaxPasswordTries = () => {
+  alert(TOO_MANY_PASSWORD_ATTEMPTS)
+}
 
 export const processStatementFile = async (
   file: File
 ): Promise<Transaction[]> =>
   new Promise((resolve) => {
     const r = new FileReader()
-    r.onload = () => resolve(parseStatement("kasikorn", "credit", r.result))
+    r.onload = () =>
+      resolve(
+        parseStatement("kasikorn", "credit", r.result, {
+          handleRequestPassword,
+          handleMaxPasswordTries,
+        })
+      )
 
     r.readAsArrayBuffer(file)
   })

--- a/packages/parser/@types/PasswordHandler.ts
+++ b/packages/parser/@types/PasswordHandler.ts
@@ -1,0 +1,8 @@
+export type RequestPasswordHandler = (
+  updatePassword: (password: string) => void
+) => void;
+export type MaxPasswordTriesHandler = () => void;
+export type PasswordHandler = {
+  handleRequestPassword: RequestPasswordHandler;
+  handleMaxPasswordTries: MaxPasswordTriesHandler;
+};

--- a/packages/parser/constant/password.ts
+++ b/packages/parser/constant/password.ts
@@ -1,6 +1,1 @@
-const MAX_NUMBER_OF_TRIES = 3;
-const TOO_MANY_PASSWORD_ATTEMPTS =
-  "Too many password attempts. Please try again later.";
-const ENTER_PASSWORD = "Please enter the password for the PDF file.";
-
-export { MAX_NUMBER_OF_TRIES, TOO_MANY_PASSWORD_ATTEMPTS, ENTER_PASSWORD };
+export const MAX_NUMBER_OF_TRIES = 3

--- a/packages/parser/constant/password.ts
+++ b/packages/parser/constant/password.ts
@@ -1,0 +1,6 @@
+const MAX_NUMBER_OF_TRIES = 3;
+const TOO_MANY_PASSWORD_ATTEMPTS =
+  "Too many password attempts. Please try again later.";
+const ENTER_PASSWORD = "Please enter the password for the PDF file.";
+
+export { MAX_NUMBER_OF_TRIES, TOO_MANY_PASSWORD_ATTEMPTS, ENTER_PASSWORD };

--- a/packages/parser/index.ts
+++ b/packages/parser/index.ts
@@ -1,4 +1,5 @@
 import {DocumentSource} from './@types/DocumentSource'
+import {PasswordHandler} from './@types/PasswordHandler'
 import {Transaction} from './@types/Transaction'
 import {parseKasikornCreditStatement} from './parsers/kasikorn.credit'
 import {extractTextChunksFromPDF} from './utils/extractTextChunksFromPDF'
@@ -11,9 +12,11 @@ export type {Transaction} from './@types/Transaction'
 export async function parseStatement(
   bank: Bank,
   type: StatementType,
-  source: DocumentSource
+  source: DocumentSource,
+  passwordHandler: PasswordHandler
 ): Promise<Transaction[]> {
-  const rawChunks = await extractTextChunksFromPDF(source)
+  
+  const rawChunks = await extractTextChunksFromPDF(source, passwordHandler)
 
   if (bank === 'kasikorn' && type === 'credit')
     return parseKasikornCreditStatement(rawChunks)

--- a/packages/parser/utils/extractTextChunksFromPDF.ts
+++ b/packages/parser/utils/extractTextChunksFromPDF.ts
@@ -1,7 +1,8 @@
 import {getDocument, GlobalWorkerOptions} from 'pdfjs-dist'
 
 import {DocumentSource} from '../@types/DocumentSource'
-import {ENTER_PASSWORD, MAX_NUMBER_OF_TRIES, TOO_MANY_PASSWORD_ATTEMPTS} from '../constant/password'
+import {PasswordHandler} from '../@types/PasswordHandler';
+import { MAX_NUMBER_OF_TRIES } from '../constant/password';
 
 /**
  * Extracts chunks of texts from PDF.
@@ -9,7 +10,8 @@ import {ENTER_PASSWORD, MAX_NUMBER_OF_TRIES, TOO_MANY_PASSWORD_ATTEMPTS} from '.
  * @todo write tests for this - find a sample source we can use in tests.
  **/
 export async function extractTextChunksFromPDF(
-  source: DocumentSource
+  source: DocumentSource, 
+  { handleRequestPassword, handleMaxPasswordTries }: PasswordHandler
 ): Promise<string[][]> {
   // Initialize PDF.js workers
   if (typeof window !== 'undefined' && !GlobalWorkerOptions.workerSrc) {
@@ -27,12 +29,12 @@ export async function extractTextChunksFromPDF(
     _: any
   ) => {
     if (++numberOfTries > MAX_NUMBER_OF_TRIES) {
-      alert(TOO_MANY_PASSWORD_ATTEMPTS)
-      return;
+      handleMaxPasswordTries()
+      return
     }
-    const password = prompt(ENTER_PASSWORD)
-    updatePassword(password)
+    handleRequestPassword(updatePassword)
   }
+  
 
   const document = await documentProvider.promise
   const pages: string[][] = []

--- a/packages/parser/utils/extractTextChunksFromPDF.ts
+++ b/packages/parser/utils/extractTextChunksFromPDF.ts
@@ -1,6 +1,7 @@
 import {getDocument, GlobalWorkerOptions} from 'pdfjs-dist'
 
 import {DocumentSource} from '../@types/DocumentSource'
+import {ENTER_PASSWORD, MAX_NUMBER_OF_TRIES, TOO_MANY_PASSWORD_ATTEMPTS} from '../constant/password'
 
 /**
  * Extracts chunks of texts from PDF.
@@ -16,8 +17,24 @@ export async function extractTextChunksFromPDF(
       'pdfjs-dist/build/pdf.worker.entry'
     )
   }
+  
+  const documentProvider = getDocument(source);
 
-  const document = await getDocument(source).promise
+  let numberOfTries = 0;
+
+  documentProvider.onPassword = (
+    updatePassword: (password: string) => void,
+    _: any
+  ) => {
+    if (++numberOfTries > MAX_NUMBER_OF_TRIES) {
+      alert(TOO_MANY_PASSWORD_ATTEMPTS)
+      return;
+    }
+    const password = prompt(ENTER_PASSWORD)
+    updatePassword(password)
+  }
+
+  const document = await documentProvider.promise
   const pages: string[][] = []
 
   for (let numPage = 1; numPage <= document.numPages; numPage++) {


### PR DESCRIPTION
PR for #2 

In my view, instead of having input fields in the UI for all documents, we could make use of the `onPassword` callback of `getDocument` to request the document password from the user. This approach is demonstrated in the example shown below. 

<img width="1781" alt="Screenshot 2566-03-09 at 20 16 23" src="https://user-images.githubusercontent.com/52349645/224034576-fd57766f-7007-46ae-b485-0c1e7cb68f69.png">

Additionally, to avoid an infinite loop of password requests, we should set a maximum number of password input attempts, such as the limit of 3 that I have chosen. 


<img width="1781" alt="Screenshot 2566-03-09 at 20 16 11" src="https://user-images.githubusercontent.com/52349645/224034522-e0e3f955-ec33-465b-ab95-dc9dda4eb546.png">


