### PR TITLE
fix: unexpected result from `findBankType` function in the parser

### DIFF
--- a/apps/visualizer/src/pages/home.tsx
+++ b/apps/visualizer/src/pages/home.tsx
@@ -84,7 +84,7 @@ export default function Home() {
     await Promise.all(
       files.map(async (file) => {
         const transactions = (await processStatementFile(file)).sort(
-          (txa, txb) => +txb.paymentDate - +txa.paymentDate
+          (txa, txb) => +(txb?.paymentDate || 0) - +(txa?.paymentDate || 0)
         )
 
         const billName = file.name
@@ -277,7 +277,7 @@ export default function Home() {
                     >
                       {formatNumber(
                         selectedStatement()?.txs?.reduce(
-                          (acc, cur) => acc + cur.amount,
+                          (acc, cur) => acc + cur?.amount || 0,
                           0
                         )
                       )}

--- a/packages/parser/index.ts
+++ b/packages/parser/index.ts
@@ -9,9 +9,9 @@ import {parseCitibankCreditStatement} from './parsers/citibank.credit'
 import {extractTextChunksFromPDF} from './utils/extractTextChunksFromPDF'
 import {parseKasikornBankStatement} from './parsers/kasikorn.statement'
 
-const bankType = ['kasikorn', 'ktc', 'citibank'] as const
+const bankTypes = ['kasikorn', 'ktc', 'citibank'] as const
 
-export type Bank = (typeof bankType)[number]
+export type Bank = (typeof bankTypes)[number]
 
 export type StatementType = 'credit' | 'account'
 
@@ -25,9 +25,17 @@ const findStatementType = (s: string): StatementType => {
 }
 
 const findBankType = (s: string): Bank => {
-  for (const bank of bankType) {
-    if (s.toLowerCase().includes(bank)) return bank
-  }
+  const lowerString = s.toLowerCase()
+
+  const foundIndexes = bankTypes.map(bank => {
+    const idx = lowerString.indexOf(bank)
+    return idx >= 0 ? idx : 1_000_000
+  })
+
+  const minIdx = Math.min(...foundIndexes)
+  const bankIdx = foundIndexes.indexOf(minIdx)
+  const foundBank = bankTypes[bankIdx]
+  return foundBank
 }
 
 export async function parseStatement(

--- a/packages/parser/index.ts
+++ b/packages/parser/index.ts
@@ -27,14 +27,16 @@ const findStatementType = (s: string): StatementType => {
 const findBankType = (s: string): Bank => {
   const lowerString = s.toLowerCase()
 
-  const foundIndexes = bankTypes.map(bank => {
+  const foundBankIndexes = bankTypes.map(bank => {
     const idx = lowerString.indexOf(bank)
     return idx >= 0 ? idx : 1_000_000
   })
 
-  const minIdx = Math.min(...foundIndexes)
-  const bankIdx = foundIndexes.indexOf(minIdx)
+  const minimumFoundBankIdx = Math.min(...foundBankIndexes)
+
+  const bankIdx = foundBankIndexes.indexOf(minimumFoundBankIdx)
   const foundBank = bankTypes[bankIdx]
+
   return foundBank
 }
 

--- a/packages/parser/parsers/ktc.credit.ts
+++ b/packages/parser/parsers/ktc.credit.ts
@@ -34,7 +34,6 @@ export function extractTextChunksFromLine(contents: string[]): string[][] {
   // Only include line items that starts with 2 dates, the transaction date and the payment date.
   // Also, only include line items that has over 3 chunks.
   // Also, remove "Payment-BAY"
-  console.log(textChunks);
   const result = textChunks
     .filter((g) => isDate(g[0]) && isDate(g[1]))
     .filter((g) => g.length > 3)


### PR DESCRIPTION
My PDF contains the keywords both `KTC` and `Kasikorn`.

Expected Result: `ktc`
Actual Result: `kasikorn`

Reproduce...
https://tsplay.dev/Nroezm